### PR TITLE
Windows CI using AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
 
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
-  - git fetch --unshallow
+  - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.init(); Pkg.clone(pwd(), \"Requests\")"
 
 test_script:


### PR DESCRIPTION
AppVeyor is a CI service much like Travis, but for Windows. It takes about 10 minutes to set up all the dependencies for Requests, but once it does the tests all pass on both 32 bit and 64 bit Windows (with some deprecation warnings): https://ci.appveyor.com/project/tkelman/requests-jl/build/1.0.3

Hopefully useful to get this running so it stays that way.
