### PR TITLE
Add port to Host header if port is not default.

### DIFF
--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -47,7 +47,8 @@
         if uri.userinfo != "" && !haskey(headers,"Authorization")
             headers["Authorization"] = "Basic "*bytestring(encode(Base64, uri.userinfo))
         end
-        default_request(method,resource,uri.host,data,headers)
+        host = uri.port == 0 ? uri.host : "$(uri.host):$(uri.port)"
+        default_request(method,resource,host,data,headers)
     end
 
     ### Response Parsing


### PR DESCRIPTION
I got burned by this a minute ago. According to the standard (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) the `Host` header should include the port number unless the request is using the protocol's default port. The previous behavior was to never include the port in the `Host` header. I have changed it to include the port unless `uri.port` is zero (in which case no port was provided, which will result in using the default port for HTTP or HTTPS).
