### PR TITLE
set Response.finished = true in on_message_complete()

### DIFF
--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -149,6 +149,7 @@
     function on_message_complete(parser)
         p = pd(parser)
         r = p.current_response
+        r.finished = true
         close(p.sock)
 
         # delete the temporary header key


### PR DESCRIPTION
I'm not sure if Response.finished is actually used anywhere, but this seems like a reasonable place to set it to true.
