### PR TITLE
Add support for HTTP compressed responses

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ GnuTLS
 Codecs
 JSON
 Compat
+Zlib

--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -10,6 +10,7 @@
     using GnuTLS
     using Codecs
     using JSON
+    using Zlib
 
     export URI, get, post, put, delete, head, options, patch, FileParam
 
@@ -234,6 +235,9 @@
             end
         end
         http_parser_execute(rp.parser,rp.settings,"") #EOF
+        if in(get(r.headers,"Content-Encoding",""), ("gzip","deflate"))
+            r.data = bytestring(decompress(r.data))
+        end
         r
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,3 +149,7 @@ end
 
 # Test for chunked responses (we expect 100 from split as there are 99 '\n')
 @test size(split(get("http://httpbin.org/stream/99").data, "\n"), 1) == 100
+
+# Test for gzipped responses
+@test JSON.parse(get("http://httpbin.org/gzip").data)["gzipped"] == true
+@test JSON.parse(get("http://httpbin.org/deflate").data)["deflated"] == true


### PR DESCRIPTION
Add support for gzipped/deflated responses using Zlib.jl, including tests from httpbin.
Also fixes #21 