### PR TITLE
add data() Response getter for Response.data

### DIFF
--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -1,7 +1,7 @@
 __precompile__()
 module Requests
 
-export URI, FileParam, headers, cookies, statuscode, post, requestfor
+export URI, FileParam, headers, data, cookies, statuscode, post, requestfor
 export get_streaming, post_streaming, write_chunked
 export view, save
 export set_proxy, set_https_proxy, get_request_settings
@@ -118,6 +118,9 @@ function mimetype(r::Response)
         return Nullable{UTF8String}()
     end
 end
+
+istext(r::Response) = any(p->ismatch(p, get(mimetype(r))), [r"^text/", r"/xml$"])
+data(r::Response) = istext(r) ? text(r) : bytes(r)
 
 function contentdisposition(r::Response)
     if haskey(headers(r), "Content-Disposition")

--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -119,7 +119,8 @@ function mimetype(r::Response)
     end
 end
 
-istext(r::Response) = any(p->ismatch(p, get(mimetype(r))), [r"^text/", r"/xml$"])
+istext(r::Response) = any(p->ismatch(p, get(mimetype(r))),
+                         [r"^text/", r"/xml$", r"/json$"])
 data(r::Response) = istext(r) ? text(r) : bytes(r)
 
 function contentdisposition(r::Response)


### PR DESCRIPTION
@tkelman commented in JuliaLang/LightXML.jl#39 ...
> ... and an Array{UInt8,1} isn't a string - if that's what your user code is dealing with then it would be more explicit to call bytestring at the call site.

This got me thinking...
The Content-Type header tells the HTTP layer (Requests.jl) what is in the Response.data bytes.
It therefore seems reasonable that HTTP layer should provide its clients with a String type where appropriate rather relying on the client to choose the right conversion function.

```julia
istext(r::Response) = any(p->ismatch(p, get(mimetype(r))), [r"^text/", r"/xml$"])
data(r::Response) = istext(r) ? text(r) : bytes(r)
``` 