### PR TITLE
Support for HTTP upgrade

### DIFF
--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -367,7 +367,9 @@ function do_stream_request(uri::URI, verb; headers = Dict{AbstractString, Abstra
         while response_stream.state < BodyDone
             wait(response_stream)
         end
-        close(response_stream)
+        if response_stream.state != UpgradeConnection
+            close(response_stream)
+        end
     end
     if write_body
         while response_stream.state < HeadersDone

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -149,7 +149,11 @@ end
 
 function on_message_complete(parser)
     response_stream = pd(parser)
-    response_stream.state = BodyDone
+    if upgrade(unsafe_load(parser))
+        response_stream.state = UpgradeConnection
+    else
+        response_stream.state = BodyDone
+    end
     notify(response_stream.state_change)
     return 0
 end

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -1,4 +1,4 @@
-@enum ResponseState NotStarted OnMessageBegin StatusComplete OnHeaderField OnHeaderValue HeadersDone OnBody BodyDone EarlyEOF
+@enum ResponseState NotStarted OnMessageBegin StatusComplete OnHeaderField OnHeaderValue HeadersDone OnBody BodyDone EarlyEOF UpgradeConnection
 
 type ResponseStream{T<:IO} <: IO
     response::Response


### PR DESCRIPTION
This adds support for upgrading a HTTP connection. HTTP upgrades is used to "upgrade" the connection to a different protocol. My particular use case is upgrading an HTTP connection to a WebSocket.

Both http-parser from Joyent and the Julia wrapper for it supports upgrading, so getting it work actually required minimal changes, as you can see below.

In short, we create a new state UpgradeConnection, like BodyDone, and we use this to ensure that the connection isn't closed, since it should live on after this request. In the http-parser callback `on_message_complete` we check the upgrade flag that http-parser sets for us.

I created a very simple script to test that it works, at least minimally. This uses a public echo service, which just echoes back any WebSocket message sent to it. It seems to work, both with http and https.

```
import Requests

uri = Requests.URI("https://echo.websocket.org")

headers = Dict{Any,Any}(
    "Connection" => "upgrade",
    "Upgrade"    => "websocket",
    "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
    "Sec-WebSocket-Version" => "13")

s = Requests.do_stream_request(uri, "GET"; headers=headers, tls_conf = Requests.TLS_NOVERIFY)

# A WebSocket message with the payload "Hello"
message = b"\x81\x85\x37\xfa\x21\x3d\x7f\x9f\x4d\x51\x58"
write(s.socket, message)

while !eof(s.socket)
    data = readavailable(s.socket)
    println("Data: $(data)")
end
```

Expected output is

```
Data: UInt8[0x81,0x05,0x48,0x65,0x6c,0x6c,0x6f]
```
