### PR TITLE
Support for multiple query params with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ options("http://httpbin.org/get")
 
 ```julia
 get("http://httpbin.org/get"; query = Dict("title" => "page1"))
+get("http://httpbin.org/get"; query = Dict("multi" => ["value1", "value2"]))
 ```
 
 ### Add plain text data

--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -229,7 +229,11 @@ function format_query_str(queryparams; uri = URI(""))
     query_str = isempty(uri.query) ? string() : string(uri.query, "&")
 
     for (k, v) in queryparams
-        query_str *= "$(URIParser.escape(string(k)))=$(URIParser.escape(string(v)))&"
+        if isa(v, Array)
+            query_str *= join(map(vi -> "$(URIParser.escape(string(k)))=$(URIParser.escape(string(vi)))", v), "&") * "&"
+        else
+            query_str *= "$(URIParser.escape(string(k)))=$(URIParser.escape(string(v)))&"
+        end
     end
     chop(query_str) # remove the trailing &
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,9 +18,11 @@ import Requests: get, post, put, delete, options, bytes, text, json, history
 
 data = json(get("http://httpbin.org/get";
                       query = Dict("key1" => "value1",
-                                   "key with spaces" => "value with spaces")))
+                                   "key with spaces" => "value with spaces",
+                                   "key2" => ["value2.1", "value2.2"])))
 @test data["args"]["key1"] == "value1"
 @test data["args"]["key with spaces"] == "value with spaces"
+@test data["args"]["key2"] == ["value2.1", "value2.2"]
 
 data = json(post("http://httpbin.org/post";
                        query = Dict("key1" => "value1",


### PR DESCRIPTION
The CGI specification allows for multiple query string parameters with
the same name.  This patch adds support for the same by passing in an
Array as the value for the query Dict.

Tests & docs updated accordingly
