### PR TITLE
Fix OPTIONS test with JSON parsing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,13 +50,11 @@ data = json(delete("http://httpbin.org/delete";
 @test data["args"]["key4"] == "4.01"
 @test data["args"]["key with spaces"] == "value with spaces"
 
-data = json(options("http://httpbin.org/get";
-                          query = Dict("key1" => "value1",
-                                       "key2" => "value2",
-                                       "key3" => 3,
-                                       "key4" => 4.01)))
-@test data == nothing
-
+@test isempty(readall(options("http://httpbin.org/get";
+                                    query = Dict("key1" => "value1",
+                                                 "key2" => "value2",
+                                                 "key3" => 3,
+                                                 "key4" => 4.01))))
 
 # check data -------
 


### PR DESCRIPTION
There is no body for the response to an OPTIONS request, and hence nothing to parse into JSON. This test should have tested the lack of a response body instead.

@malmaud With regards to:

> As far as I can tell, JSON being sent back from httpbin.org is being rejected, which suggests that if there is new pickiness in JSON.jl, it's inappropriate.

That `JSON.parse` used to return `nothing` for an empty string is completely nonstandard (not present in Python, JavaScript, nor the standard, nor allowed by any [linters](http://jsonlint.com/)). What httpbin.org is "sending back" here is not JSON at all. It was never intended to be parsed as JSON to begin with. Luckily, I think it was only this test relying on this; I doubt actual code is trying to parse the empty body of an OPTIONS request as JSON.

Ref https://github.com/JuliaLang/METADATA.jl/pull/5398

(PS: Base seems to be moving from `readall` and `readbytes` to `readstring` and `read`. Worth rethinking the names in this package also.)