### PR TITLE
`convert` has no method matching convert(::Type{AbstractString}, ::Array{UInt8,1}) when using basic auth

### DIFF
--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -215,7 +215,7 @@ end
 function default_request(uri::URI,headers,data,method)
     resource = resourcefor(uri)
     if !isempty(uri.userinfo) && !haskey(headers,"Authorization")
-        headers["Authorization"] = "Basic $(String(encode(Base64, uri.userinfo)))"
+        headers["Authorization"] = "Basic $(bytestring(encode(Base64, uri.userinfo)))"
     end
     host = uri.port == 0 ? uri.host : "$(uri.host):$(uri.port)"
     request = default_request(method,resource,host,data,headers)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ import Requests: get, post, put, delete, options, bytes, text, json, history
 @test delete("http://httpbin.org/delete").status == 200
 @test options("http://httpbin.org/get").status == 200
 
+# basic authorization encoding
+data = json(get("https://user:password@httpbin.org/get"))
+@test data["headers"]["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
 
 # check query params -------
 


### PR DESCRIPTION
I ran into this error and was able to solve it by using the example from the Codecs docs to get the string.

Weirdly I've not been able to get the tests to run due to `ERROR (unhandled task failure): ReadOnlyMemoryError()`.