### PR TITLE
HTTP/2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ delete("http://httpbin.org/delete")
 options("http://httpbin.org/get")
 ```
 
+To make a HTTP/2 request, use:
+
+```julia
+get("https://http2.golang.org/"; http2=true)
+```
+
+Note that most servers that do support HTTP/2 only support it over HTTPS.
+
 ### Add query parameters
 
 ```julia
@@ -178,3 +186,5 @@ write_chunked(stream, "")  # Signal that the body is complete
 response = readall(stream)  # Get back the server's response
 
 ```
+
+Streaming is not supported over HTTP/2 because HTTP/2 is a binary protocol. To work with streaming data, use `HTTP2` library directly.

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.4
 HttpCommon 0.2.4
 HttpParser
 URIParser 0.1.1
-MbedTLS 0.2.6
+MbedTLS 0.2.1
 Codecs
 JSON
 Libz

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,8 +2,9 @@ julia 0.4
 HttpCommon 0.2.4
 HttpParser
 URIParser 0.1.1
-MbedTLS 0.2.1
+MbedTLS 0.2.6
 Codecs
 JSON
 Libz
 Compat 0.8.0
+HTTP2 0.1.0

--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -215,7 +215,7 @@ end
 function default_request(uri::URI,headers,data,method)
     resource = resourcefor(uri)
     if !isempty(uri.userinfo) && !haskey(headers,"Authorization")
-        headers["Authorization"] = "Basic $(encode(Base64, uri.userinfo))"
+        headers["Authorization"] = "Basic $(base64encode(uri.userinfo))"
     end
     host = uri.port == 0 ? uri.host : "$(uri.host):$(uri.port)"
     request = default_request(method,resource,host,data,headers)

--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -108,11 +108,11 @@ history(r::Response) = r.history
 
 # Stolen from https://github.com/dcjones/Gadfly.jl/blob/7fd56991e55b6617d37d7e3d0d69a310bdd36b05/src/Gadfly.jl#L1016
 function open_file(filename)
-    if OS_NAME == :Darwin
+    if is_apple()
         run(`open $(filename)`)
-    elseif OS_NAME == :Linux || OS_NAME == :FreeBSD
+    elseif is_unix()
         run(`xdg-open $(filename)`)
-    elseif OS_NAME == :Windows
+    elseif is_windows()
         run(`$(ENV["COMSPEC"]) /c start $(filename)`)
     end
 end

--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -3,7 +3,7 @@ module Requests
 
 export URI, FileParam, headers, cookies, statuscode, post, requestfor
 export get_streaming, post_streaming, write_chunked
-export view, save
+export save
 export set_proxy, set_https_proxy, get_request_settings
 
 import Base: get, write

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -187,7 +187,7 @@ function open_stream(req::Request, tls_conf=TLS_VERIFY, timeout=Inf,
     else
         # Initialize HTTPS
         if connect_method == :tunnel
-            sock = Base.connect(ip, http_port(uri))
+            sock = Base.connect(ip, https_port(uri))
             tunnel_req = Request()
             tunnel_req.method = "CONNECT"
             tunnel_resp = Response()
@@ -214,6 +214,34 @@ function open_stream(req::Request, tls_conf=TLS_VERIFY, timeout=Inf,
     stream = ResponseStream(resp, stream)
     stream.timeout = timeout
     send_headers(stream)
+    stream
+end
+
+function open_http_socket(uri::URI)
+    ip = Base.getaddrinfo(uri.host)
+    sock = Base.connect(ip, http_port(uri))
+
+    sock
+end
+
+function open_https_socket(uri::URI, tls_conf=TLS_VERIFY, http2=false)
+    @assert scheme(uri) == "https"
+
+    ip = Base.getaddrinfo(uri.host)
+    sock = Base.connect(ip, https_port(uri))
+
+    if http2
+        MbedTLS.set_alpn!(tls_conf, ["h2"])
+    end
+
+    stream = MbedTLS.SSLContext()
+    MbedTLS.setup!(stream, tls_conf)
+    MbedTLS.set_bio!(stream, sock)
+    MbedTLS.hostname!(stream, uri.host)
+    MbedTLS.handshake(stream)
+    if http2
+        @assert MbedTLS.alpn_proto(stream) == "h2"
+    end
     stream
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ import Requests: get, post, put, delete, options, bytes, text, json, history
 @test delete("http://httpbin.org/delete").status == 200
 @test options("http://httpbin.org/get").status == 200
 
+@test get("https://http2.golang.org", http2=true).status == 200
 
 # check query params -------
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,3 +246,7 @@ if get(ENV, "REQUESTS_TEST_PROXY", "0") == "1"
     run(`docker rm -v squid`)
     run(`docker-machine rm proxytest`)
 end
+
+# Basic auth
+@test get("https://user:pw@httpbin.org/basic-auth/user/pw").status == 200
+@test get("https://user:wrongpw@httpbin.org/basic-auth/user/pw").status == 401


### PR DESCRIPTION
This pull request adds HTTP/2 support for Requests.jl. Help on testing and code review are highly appreciated!

To use it, you need to checkout `master` of [HPack.jl](http://github.com/sorpaas/HPack.jl) (header compression implementation), [HTTP2.jl](https://github.com/sorpaas/HTTP2.jl) (HTTP/2 protocol implementation) and [MbedTLS.jl](https://github.com/JuliaWeb/MbedTLS.jl).

For a simple test, install [nghttp](https://nghttp2.org). Run in shell `nghttpd --verbose --no-tls --hexdump 9000` to start a server and then in Julia:

```
using Requests
res = get("http://127.0.0.1:9000", http2=true)

@show res.headers
```

To test HTTPS, create a test certificate and key. Start the server by `nghttpd --verbose --hexdump 9000 test.key test.crt` and then in Julia:

```
using Requests
res = get("https://127.0.0.1:9000", tls_conf=Requests.TLS_NOVERIFY, http2=true)

@show res.headers
```

You can also test it against a server in the real world. Usually, wild HTTP/2 servers require HTTPS support.

```
using Requests
res = get("https://www.google.com", http2=true)
```