### PR TITLE
Disallow reading from a closed ResponseStream

### DIFF
--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -127,7 +127,7 @@ function Base.read(stream::ResponseStream)
     while stream.state < BodyDone
         wait(stream)
     end
-    take!(stream.buffer)
+    read(stream.buffer)
 end
 
 function Base.read(stream::ResponseStream, ::Type{UInt8})
@@ -144,7 +144,12 @@ function Base.readavailable(stream::ResponseStream)
     read(stream, nb_available(stream))
 end
 
-Base.close(stream::ResponseStream) = close(stream.socket)
+function Base.close(stream::ResponseStream)
+    close(stream.socket)
+    seekend(stream.buffer)
+    nothing
+end
+
 Base.nb_available(stream::ResponseStream) = nb_available(stream.buffer)
 
 for getter in [:headers, :cookies, :statuscode, :requestfor, :history]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,6 +218,11 @@ let
         N += length(bytes)
     end
     @test N==100
+
+    stream = Requests.get_streaming("http://httpbin.org/stream-bytes/100", query=Dict(:chunk_size=>10))
+    close(stream)
+    @test eof(stream)
+    @test isempty(read(stream))
 end
 
 # Proxy testing. Would be better to use a real proxy instead of using the real site


### PR DESCRIPTION
Closing a `ResponseStream` would still allow you to continue reading content from the buffer. I've updated the code to work similarly to how `IOStream`'s behave.