### PR TITLE
reduce request fragmentation

### DIFF
--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -33,10 +33,12 @@ end
 
 function send_headers(response_stream::ResponseStream)
     request = requestfor(response_stream)
-    print(response_stream, request.method, " ", isempty(request.resource) ? "/" : request.resource,
+    buf = IOBuffer()
+    print(buf, request.method, " ", isempty(request.resource) ? "/" : request.resource,
           " HTTP/1.1", CRLF,
           map(h->string(h,": ",request.headers[h],CRLF), collect(keys(request.headers)))...,
           "", CRLF)
+    write(response_stream, take!(buf))
     response_stream
 end
 


### PR DESCRIPTION
`print` calls `write` multiple times which results in unnecessary fragmentation on the stream.  Try to insure that the entire request is sent out in as few packets as possible by making it a single write.