### PR TITLE
UTF8String -> String to remove deprecation warnings

### DIFF
--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -85,7 +85,7 @@ get_request_settings() = SETTINGS
 ## Convenience methods for extracting the payload of a response
 for kind in [:Response, :Request]
     @eval bytes(r::$kind) = r.data
-    @eval text(r::$kind) = Compat.String(bytes(r))
+    @eval text(r::$kind) = String(bytes(r))
     if VERSION < v"0.5.0-dev+4194"
         @eval Base.bytestring(r::$kind) = text(r)
     else
@@ -142,7 +142,7 @@ function mimetype(r::Response)
         ct = split(headers(r)["Content-Type"], ";")[1]
         return Nullable(ct)
     else
-        return Nullable{Compat.UTF8String}()
+        return Nullable{String}()
     end
 end
 
@@ -156,7 +156,7 @@ function contentdisposition(r::Response)
             end
         end
     end
-    return Nullable{Compat.UTF8String}()
+    return Nullable{String}()
 end
 
 """

--- a/src/mimetypes.jl
+++ b/src/mimetypes.jl
@@ -2,7 +2,7 @@
 
 using Compat
 
-const MIMETYPES = Dict{Compat.UTF8String, Compat.UTF8String}()
+const MIMETYPES = Dict{String, String}()
 
 MIMETYPES["application/andrew-inset"]="ez"
 MIMETYPES["application/applixware"]="aw"

--- a/src/multipart.jl
+++ b/src/multipart.jl
@@ -30,9 +30,9 @@ write(io::ChunkedStream, arg) = write_chunked(io.io, arg)
 immutable FileParam
     file::Union{IO,Base.File,AbstractString,Vector{UInt8}}     # The file
     # The content type (default: "", which is interpreted as text/plain serverside)
-    ContentType::Compat.UTF8String
-    name::Compat.UTF8String                     # The fieldname (in a form)
-    filename::Compat.UTF8String                              # The filename (of the actual file)
+    ContentType::String
+    name::String                     # The fieldname (in a form)
+    filename::String                              # The filename (of the actual file)
     # Whether or not to close the file when the request is done
     close::Bool
 
@@ -199,7 +199,7 @@ end
 
 immutable MultipartSettings
     datasizes::Vector{Int}
-    boundary::Compat.UTF8String
+    boundary::String
     chunked::Bool
 end
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -68,7 +68,7 @@ function parse_cookies!(response, cookie_strings)
                 name, value = nameval
                 c.attrs[strip(name)] = strip(value)
             else
-                c.attrs[strip(nameval[1])] = Compat.String("")
+                c.attrs[strip(nameval[1])] = ""
             end
         end
         response.cookies[c.name] = c
@@ -121,7 +121,7 @@ function on_headers_complete(parser)
     response.headers["http_major"] = string(convert(Int, p.http_major))
     response.headers["http_minor"] = string(convert(Int, p.http_minor))
     response.headers["Keep-Alive"] = string(http_should_keep_alive(parser))
-    parse_cookies!(response, Compat.String(take!(response_stream.cookie_buffer)))
+    parse_cookies!(response, String(take!(response_stream.cookie_buffer)))
 
     response_stream.state = HeadersDone
     notify(response_stream.state_change)

--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -7,7 +7,7 @@ type ResponseStream{T<:IO} <: IO
     buffer::IOBuffer
     parser::ResponseParser
     timeout::Float64
-    current_header::Nullable{Compat.UTF8String}
+    current_header::Nullable{String}
     state_change::Condition
     cookie_buffer::IOBuffer
     #Replace with `ResponseStream{T}() where T` when dropping support for 0.5


### PR DESCRIPTION
Along with https://github.com/JuliaWeb/HttpCommon.jl/pull/45, this fixes all of the deprecation warnings for `Compat.UTF8String`

Fixes #162 