### PR TITLE
Identifying possible error for Issue #164.

### DIFF
--- a/src/streaming.jl
+++ b/src/streaming.jl
@@ -64,6 +64,7 @@ function process_response(stream)
         end
     end
     @schedule begin
+        try
         while stream.state < BodyDone && !eof(stream.socket)
             last_received = now()
             data = readavailable(stream.socket)
@@ -72,6 +73,9 @@ function process_response(stream)
             end
         end
         put!(status_channel, :success)
+        catch exc
+            put!(status_channel, :timeout)
+        end
     end
     status = take!(status_channel)
     status == :timeout && throw(TimeoutException(timeout))


### PR DESCRIPTION
I do not intend to fix the issue as I do not understand the code in this area much. However, from the analysis I can see the @schedule section is pretty much at the top of a stack, hence unhandled exception will not be able to proceed further. I have just forced a timeout at that point for the code to proceed. And I could download almost 5000 files from there. 

In #164, the server in interest is forcing a connection closure on the 150th download for a client forcing it to reestablish a connection. This could be the servers mechanism against DoS attacks. As a connection closure is enforced the eof function is throwing an exception and hence the hanging behavior. Putting appropriate exception handling can address the issue. 

Please review and provide the most appropriate error handling needed.  